### PR TITLE
refactor: User::isBlocked -> User::getBlock

### DIFF
--- a/BlockAppealEmail.php
+++ b/BlockAppealEmail.php
@@ -10,7 +10,7 @@ class BlockAppealEmail {
 		//disable caching so that the block information is truly up to date
 		$parser->getOutput()->updateCacheExpiry(0);
 		
-		if ($parser->getUser()->isBlocked()) {
+		if ($parser->getUser()->getBlock()) {
 			return $wgBlockAppealEmail;
 		} else {
 			return empty($body) ? '' : $parser->recursiveTagParse($body);


### PR DESCRIPTION
User::isBlocked is deprecated, switching to User::getBlock which returns null to indicate "no block".